### PR TITLE
Added class capable of parsing out analytics config file

### DIFF
--- a/example/dash_analytics_example.dart
+++ b/example/dash_analytics_example.dart
@@ -58,6 +58,8 @@ void main() async {
   DateTime start = DateTime.now();
   print('###### START ###### $start');
 
+  print(analytics.telemetryEnabled);
+
   DateTime end = DateTime.now();
   print(
       '###### DONE ###### ${DateTime.now()} ${end.difference(start).inMilliseconds}ms');

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -1,6 +1,9 @@
+import 'config_handler.dart';
 import 'initializer.dart';
 
 class Analytics {
+  final ConfigHandler _configHandler;
+
   Analytics({
     required tool,
     required homeDirectory,
@@ -12,7 +15,7 @@ class Analytics {
     required flutterVersion,
     required dartVersion,
     bool? forceReset,
-  }) {
+  }) : _configHandler = ConfigHandler(homeDirectory: homeDirectory) {
     // This initializer class will let the instance know
     // if it was the first run; if it is, nothing will be sent
     // on the first run
@@ -24,5 +27,9 @@ class Analytics {
       forceReset: forceReset ?? false,
     );
     initializer.run();
+  }
+
+  bool get telemetryEnabled {
+    return _configHandler.telemetryEnabled;
   }
 }

--- a/lib/src/config_handler.dart
+++ b/lib/src/config_handler.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:intl/intl.dart';
+import 'package:path/path.dart' as p;
+
+/// The regex pattern used to parse the disable analytics line
+const String disableTelemetryPattern = r'^(;?)reporting=([0|1]) *$';
+
+/// The regex pattern used to parse the tools info
+/// from the configuration file
+///
+/// Example:
+/// flutter-tools=2022-10-26,1
+const String toolPattern =
+    r'^([A-Za-z0-9]+-*[A-Za-z0-9]*)=([0-9]{4}-[0-9]{2}-[0-9]{2}),([0-9]+)$';
+
+class ConfigHandler {
+  final Directory homeDirectory;
+  final File configFile;
+  final File clientIdFile;
+  final Map<String, ToolInfo> parsedTools = {};
+
+  /// Reporting enabled unless specified by user
+  bool telemetryEnabled = true;
+
+  ConfigHandler({required this.homeDirectory})
+      : configFile = File(p.join(
+          homeDirectory.path,
+          '.dart-tool',
+          'dart-flutter-telemetry.config',
+        )),
+        clientIdFile = File(p.join(
+          homeDirectory.path,
+          '.dart-tool',
+          'CLIENT_ID',
+        )) {
+    parseConfig();
+  }
+
+  String get dateStamp {
+    return DateFormat('yyyy-MM-dd').format(DateTime.now());
+  }
+
+  /// Method responsible for reading in the config file stored on
+  /// user's machine and parsing out the following: all the tools that
+  /// have been logged in the file, the dates they were last run, and
+  /// determining if telemetry is enabled by parsing the file
+  void parseConfig() {
+    final RegExp toolRegex = RegExp(toolPattern, multiLine: true);
+    final RegExp disableTelemetryRegex =
+        RegExp(disableTelemetryPattern, multiLine: true);
+
+    // Read the configuration file as a string and run the two regex patterns
+    // on it to get information around which tools have been parsed and whether
+    // or not telemetry has been disabled by the user
+    final String configString = configFile.readAsStringSync();
+
+    // Collect the tools logged in the configuration file
+    toolRegex.allMatches(configString).forEach((element) {
+      // Extract the information relevant for the [ToolInfo] class
+      final String tool = element.group(1) as String;
+      final DateTime lastRun = DateTime.parse(element.group(2) as String);
+      final int versionNumber = int.parse(element.group(3) as String);
+
+      // Initialize an instance of the [ToolInfo] class to store
+      // in the [parsedTools] map object
+      parsedTools[tool] = ToolInfo(
+        lastRun: lastRun,
+        versionNumber: versionNumber,
+      );
+    });
+
+    // Check for lines signaling that the user has disabled analytics,
+    // if multiple lines are found, the more conservative value will be used
+    disableTelemetryRegex.allMatches(configString).forEach((element) {
+      // Conditional for recording telemetry as being disabled
+      if (element.group(1) != ';' && element.group(2) == '0') {
+        telemetryEnabled = false;
+      }
+    });
+  }
+}
+
+class ToolInfo {
+  DateTime lastRun;
+  int versionNumber;
+
+  ToolInfo({
+    required this.lastRun,
+    required this.versionNumber,
+  });
+
+  @override
+  String toString() {
+    return json.encode({
+      'lastRun': DateFormat('yyyy-MM-dd').format(lastRun),
+      'versionNumber': versionNumber,
+    });
+  }
+}


### PR DESCRIPTION
Intended to be part of https://github.com/eliasyishak/dash_analytics/issues/5

This new functionality will allow the main `Analytics` class to call this handler and parse out the relevant information needed from the configuration file.

Sample of what the configuration file looks like below:

<details>
  <summary>Sample</summary>

  ```
# INTRODUCTION
#
# This is the Flutter and Dart telemetry reporting
# configuration file.
#
# Lines starting with a #" are documentation that
# the tools maintain automatically.
#
# Lines starting with a ";" are comments and are
# ignored by the tools that read this file.
#
# All other lines are configuration lines. They have
# the form "name=value". If multiple lines contain
# the same configuration name with different values,
# the parser will default to a conservative value. 

# DISABLING TELEMETRY REPORTING
#
# To disable telemetry reporting, set "reporting" to
# the value "0" by uncommenting the following line:
reporting=1

# NOTIFICATIONS
#
# Each tool records when it last informed the user about
# analytics reporting and the privacy policy.
#
# The following tools have so far read this file:
#
#   dart-tools (Dart CLI developer tool)
#   devtools (DevTools debugging and performance tools)
#   flutter-tools (Flutter CLI developer tool)
#
# For each one, the file may contain a configuration line
# where the name is the code in the list above, e.g. "dart-tool",
# and the value is a date in the form YYYY-MM-DD, a comma, and
# a number representing the version of the message that was
# displayed.
flutter-tools=2022-11-23,2
dart-tools=2022-11-23,1
  ```
</details>
