### PR TITLE
Method added to ConfigHandler to add a new tool during initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 # Omit committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
+
+.vscode/

--- a/example/dash_analytics_example.dart
+++ b/example/dash_analytics_example.dart
@@ -29,7 +29,7 @@ final String tool = 'flutter-tools';
 final String measurementId = 'G-N1NXG28J5B';
 final String apiSecret = '4yT8__oER3Cd84dtx6r-_A';
 
-io.Directory getHomeDirectory() {
+Directory getHomeDirectory() {
   String? home;
   Map<String, String> envVars = io.Platform.environment;
 

--- a/example/dash_analytics_example.dart
+++ b/example/dash_analytics_example.dart
@@ -1,10 +1,15 @@
-import 'dart:io';
+import 'dart:io' as io;
+
+import 'package:file/file.dart';
+import 'package:file/local.dart';
 
 import 'package:dash_analytics/dash_analytics.dart';
 
+final FileSystem fs = LocalFileSystem();
+
 final int flutterToolsMessageVersion = 1;
 final String flutterToolsMessage = '''
-The [tool name] uses Google Analytics to report usage and diagnostic data
+Dash related tooling uses Google Analytics to report usage and diagnostic data
 along with package dependencies, and crash reporting to send basic crash
 reports. This data is used to help improve the Dart platform, Flutter framework,
 and related tools.
@@ -24,19 +29,19 @@ final String tool = 'flutter-tools';
 final String measurementId = 'G-N1NXG28J5B';
 final String apiSecret = '4yT8__oER3Cd84dtx6r-_A';
 
-Directory getHomeDirectory() {
+io.Directory getHomeDirectory() {
   String? home;
-  Map<String, String> envVars = Platform.environment;
+  Map<String, String> envVars = io.Platform.environment;
 
-  if (Platform.isMacOS) {
+  if (io.Platform.isMacOS) {
     home = envVars['HOME'];
-  } else if (Platform.isLinux) {
+  } else if (io.Platform.isLinux) {
     home = envVars['HOME'];
-  } else if (Platform.isWindows) {
+  } else if (io.Platform.isWindows) {
     home = envVars['UserProfile'];
   }
 
-  return Directory(home!);
+  return fs.directory(home!);
 }
 
 // Globally instantiate the analytics class at the entry

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'config_handler.dart';
 import 'initializer.dart';
 
@@ -27,6 +29,17 @@ class Analytics {
       forceReset: forceReset ?? false,
     );
     initializer.run();
+
+    // Initialize the config handler class and check if the
+    // tool message and version have been updated from what
+    // is in the current file; if there is a new message version
+    // make the necessary updates
+    bool messagePrinted = false;
+    if (!_configHandler.parsedTools.containsKey(tool)) {
+      _configHandler.addTool(tool: tool);
+      stdout.writeln(toolsMessage);
+      messagePrinted = true;
+    }
   }
 
   bool get telemetryEnabled {

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -34,6 +34,7 @@ class Analytics {
     // tool message and version have been updated from what
     // is in the current file; if there is a new message version
     // make the necessary updates
+    // ignore: unused_local_variable TODO: remove after increment method implemented
     bool messagePrinted = false;
     if (!_configHandler.parsedTools.containsKey(tool)) {
       _configHandler.addTool(tool: tool);

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -1,11 +1,13 @@
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+
 import 'config_handler.dart';
 import 'initializer.dart';
 
-class Analytics {
-  final ConfigHandler _configHandler;
-  late bool _showMessage;
-
-  Analytics({
+abstract class Analytics {
+  /// The default factory constructor that will return an implementation
+  /// of the [Analytics] abstract class using the [LocalFileSystem]
+  factory Analytics({
     required tool,
     required homeDirectory,
     required measurementId,
@@ -16,19 +18,60 @@ class Analytics {
     required flutterVersion,
     required dartVersion,
     bool? forceReset,
-  }) : _configHandler = ConfigHandler(homeDirectory: homeDirectory) {
+  }) =>
+      AnalyticsImpl(
+        tool: tool,
+        homeDirectory: homeDirectory,
+        measurementId: measurementId,
+        apiSecret: apiSecret,
+        toolsMessageVersion: toolsMessageVersion,
+        toolsMessage: toolsMessage,
+        branch: branch,
+        flutterVersion: flutterVersion,
+        dartVersion: dartVersion,
+      );
+
+  /// Boolean indicating whether or not telemetry is enabled
+  bool get telemetryEnabled;
+
+  /// Boolean that lets the client know if they should display the message
+  bool get shouldShowMessage;
+}
+
+class AnalyticsImpl implements Analytics {
+  final FileSystem fs;
+  late ConfigHandler _configHandler;
+  late bool _showMessage;
+
+  AnalyticsImpl({
+    required tool,
+    required homeDirectory,
+    required measurementId,
+    required apiSecret,
+    required toolsMessageVersion,
+    required toolsMessage,
+    required branch,
+    required flutterVersion,
+    required dartVersion,
+    bool forceReset = false,
+    this.fs = const LocalFileSystem(),
+  }) {
     // This initializer class will let the instance know
     // if it was the first run; if it is, nothing will be sent
     // on the first run
     final Initializer initializer = Initializer(
+      fs: fs,
       tool: tool,
       homeDirectory: homeDirectory,
       toolsMessageVersion: toolsMessageVersion,
       toolsMessage: toolsMessage,
-      forceReset: forceReset ?? false,
+      forceReset: forceReset,
     );
     initializer.run();
     _showMessage = initializer.firstRun;
+
+    // Create the config handler that will parse the config file
+    _configHandler = ConfigHandler(fs: fs, homeDirectory: homeDirectory);
 
     // Initialize the config handler class and check if the
     // tool message and version have been updated from what
@@ -40,11 +83,11 @@ class Analytics {
     }
   }
 
-  /// Boolean indicating whether or not telemetry is enabled
+  @override
   bool get telemetryEnabled {
     return _configHandler.telemetryEnabled;
   }
 
-  /// Boolean that lets the client know if they should display the message
+  @override
   bool get shouldShowMessage => _showMessage;
 }

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -1,10 +1,9 @@
-import 'dart:io';
-
 import 'config_handler.dart';
 import 'initializer.dart';
 
 class Analytics {
   final ConfigHandler _configHandler;
+  late bool _showMessage;
 
   Analytics({
     required tool,
@@ -29,21 +28,22 @@ class Analytics {
       forceReset: forceReset ?? false,
     );
     initializer.run();
+    _showMessage = initializer.firstRun;
 
     // Initialize the config handler class and check if the
     // tool message and version have been updated from what
     // is in the current file; if there is a new message version
     // make the necessary updates
-    // ignore: unused_local_variable TODO: remove after increment method implemented
-    bool messagePrinted = false;
     if (!_configHandler.parsedTools.containsKey(tool)) {
       _configHandler.addTool(tool: tool);
-      stdout.writeln(toolsMessage);
-      messagePrinted = true;
     }
   }
 
+  /// Boolean indicating whether or not telemetry is enabled
   bool get telemetryEnabled {
     return _configHandler.telemetryEnabled;
   }
+
+  /// Boolean that lets the client know if they should display the message
+  bool get shouldShowMessage => _showMessage;
 }

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -1,5 +1,6 @@
 import 'package:file/file.dart';
 import 'package:file/local.dart';
+import 'package:file/memory.dart';
 
 import 'config_handler.dart';
 import 'initializer.dart';
@@ -8,15 +9,15 @@ abstract class Analytics {
   /// The default factory constructor that will return an implementation
   /// of the [Analytics] abstract class using the [LocalFileSystem]
   factory Analytics({
-    required tool,
-    required homeDirectory,
-    required measurementId,
-    required apiSecret,
-    required toolsMessageVersion,
-    required toolsMessage,
-    required branch,
-    required flutterVersion,
-    required dartVersion,
+    required String tool,
+    required Directory homeDirectory,
+    required String measurementId,
+    required String apiSecret,
+    required int toolsMessageVersion,
+    required String toolsMessage,
+    required String branch,
+    required String flutterVersion,
+    required String dartVersion,
     bool? forceReset,
   }) =>
       AnalyticsImpl(
@@ -29,6 +30,33 @@ abstract class Analytics {
         branch: branch,
         flutterVersion: flutterVersion,
         dartVersion: dartVersion,
+      );
+
+  /// Factory constructor to return the [AnalyticsImpl] class with a
+  /// [MemoryFileSystem] to use for testing
+  factory Analytics.test({
+    required String tool,
+    required Directory homeDirectory,
+    required String measurementId,
+    required String apiSecret,
+    required int toolsMessageVersion,
+    required String toolsMessage,
+    required String branch,
+    required String flutterVersion,
+    required String dartVersion,
+    required FileSystem fs,
+  }) =>
+      AnalyticsImpl(
+        tool: tool,
+        homeDirectory: homeDirectory,
+        measurementId: measurementId,
+        apiSecret: apiSecret,
+        toolsMessageVersion: toolsMessageVersion,
+        toolsMessage: toolsMessage,
+        branch: branch,
+        flutterVersion: flutterVersion,
+        dartVersion: dartVersion,
+        fs: fs,
       );
 
   /// Boolean indicating whether or not telemetry is enabled
@@ -44,15 +72,15 @@ class AnalyticsImpl implements Analytics {
   late bool _showMessage;
 
   AnalyticsImpl({
-    required tool,
-    required homeDirectory,
-    required measurementId,
-    required apiSecret,
-    required toolsMessageVersion,
-    required toolsMessage,
-    required branch,
-    required flutterVersion,
-    required dartVersion,
+    required String tool,
+    required Directory homeDirectory,
+    required String measurementId,
+    required String apiSecret,
+    required int toolsMessageVersion,
+    required String toolsMessage,
+    required String branch,
+    required String flutterVersion,
+    required String dartVersion,
     bool forceReset = false,
     this.fs = const LocalFileSystem(),
   }) {

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -36,6 +36,7 @@ class Analytics {
     // make the necessary updates
     if (!_configHandler.parsedTools.containsKey(tool)) {
       _configHandler.addTool(tool: tool);
+      _showMessage = true;
     }
   }
 

--- a/lib/src/config_handler.dart
+++ b/lib/src/config_handler.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:file/file.dart';
 import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 
@@ -16,6 +16,7 @@ const String toolPattern =
     r'^([A-Za-z0-9]+-*[A-Za-z0-9]*)=([0-9]{4}-[0-9]{2}-[0-9]{2}),([0-9]+)$';
 
 class ConfigHandler {
+  final FileSystem fs;
   final Directory homeDirectory;
   final File configFile;
   final File clientIdFile;
@@ -24,13 +25,15 @@ class ConfigHandler {
   /// Reporting enabled unless specified by user
   bool telemetryEnabled = true;
 
-  ConfigHandler({required this.homeDirectory})
-      : configFile = File(p.join(
+  ConfigHandler({
+    required this.fs,
+    required this.homeDirectory,
+  })  : configFile = fs.file(p.join(
           homeDirectory.path,
           '.dart-tool',
           'dart-flutter-telemetry.config',
         )),
-        clientIdFile = File(p.join(
+        clientIdFile = fs.file(p.join(
           homeDirectory.path,
           '.dart-tool',
           'CLIENT_ID',

--- a/lib/src/config_handler.dart
+++ b/lib/src/config_handler.dart
@@ -80,6 +80,32 @@ class ConfigHandler {
       }
     });
   }
+
+  /// Responsibe for the creation of the configuration line
+  /// for the tool being passed in by the user and adding a
+  /// [ToolInfo] object
+  void addTool({required String tool}) {
+    // Increment the version number of any existing tools
+    // that already exist in configuration file by using
+    // the [incrementToolVersion] method
+    if (parsedTools.containsKey(tool)) {
+      // TODO: implement method to increment the tool if it
+      //  already exists in the config file
+    }
+
+    // Create the new instance of [ToolInfo] to be added
+    // to the [parsedTools] map
+    final DateTime now = DateTime.now();
+    parsedTools[tool] = ToolInfo(lastRun: now, versionNumber: 1);
+
+    // New string to be appended to the bottom of the configuration file
+    // with a newline character for new tools to be added
+    String newTool = '$tool=$dateStamp,1\n';
+    if (!configFile.readAsStringSync().endsWith('\n')) {
+      newTool = '\n$newTool';
+    }
+    configFile.writeAsStringSync(newTool, mode: FileMode.append);
+  }
 }
 
 class ToolInfo {

--- a/lib/src/initializer.dart
+++ b/lib/src/initializer.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'dart:io';
 
+import 'package:file/file.dart';
 import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 
@@ -65,9 +65,6 @@ void createConfigFile({
 # displayed.
 $tool=$dateStamp,$toolsMessageVersion
 ''');
-
-  stdout.writeln('Generated the new config file at ${configFile.path}\n');
-  stdout.writeln(toolsMessage);
 }
 
 /// Creates the session json file which will contain
@@ -84,6 +81,7 @@ createSessionFile({required File sessionFile}) {
 }
 
 class Initializer {
+  final FileSystem fs;
   final String tool;
   final Directory homeDirectory;
   final int toolsMessageVersion;
@@ -104,6 +102,7 @@ class Initializer {
   /// Passing [forceReset] as true will only reset the configuration
   /// file, it won't recreate the client id file
   Initializer({
+    required this.fs,
     required this.tool,
     required this.homeDirectory,
     required this.toolsMessageVersion,
@@ -120,7 +119,7 @@ class Initializer {
   /// If it doesn't exist, one will be created there
   void run() {
     // Begin by checking for the 'dart-flutter-telemetry.config'
-    final File configFile = File(p.join(
+    final File configFile = fs.file(p.join(
         homeDirectory.path, '.dart-tool', 'dart-flutter-telemetry.config'));
 
     // When the config file doesn't exist, initialize it with the default tools
@@ -138,14 +137,14 @@ class Initializer {
 
     // Begin initialization checks for the client id
     final File clientFile =
-        File(p.join(homeDirectory.path, '.dart-tool', 'CLIENT_ID'));
+        fs.file(p.join(homeDirectory.path, '.dart-tool', 'CLIENT_ID'));
     if (!clientFile.existsSync()) {
       createClientIdFile(clientFile: clientFile);
     }
 
     // Begin initialization checks for the session file
     final File sessionFile =
-        File(p.join(homeDirectory.path, '.dart-tool', 'session.json'));
+        fs.file(p.join(homeDirectory.path, '.dart-tool', 'session.json'));
     if (!sessionFile.existsSync()) {
       createSessionFile(sessionFile: sessionFile);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dash_analytics
-description: A starting point for Dart libraries or applications.
+description: A package for logging analytics for all dash related tooling to Google Analytics
 version: 1.0.0
 # repository: https://github.com/my_org/my_repo
 
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.19.0-406.0.dev <3.0.0'
 
 dependencies:
+  file: ^6.1.4
   http: ^0.13.5
   intl: ^0.17.0
   path: ^1.8.0

--- a/test/dash_analytics_test.dart
+++ b/test/dash_analytics_test.dart
@@ -1,5 +1,54 @@
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:test/test.dart';
 
 import 'package:dash_analytics/dash_analytics.dart';
 
-void main() {}
+void main() {
+  late FileSystem fs;
+  late Directory home;
+  late Directory dartToolDirectory;
+  late Analytics analytics;
+
+  setUp(() {
+    // Setup the filesystem with the home directory
+    fs = MemoryFileSystem();
+    home = fs.directory('home');
+    dartToolDirectory = home.childDirectory('.dart-tool');
+
+    analytics = Analytics.test(
+      tool: 'tool',
+      homeDirectory: home,
+      measurementId: 'measurementId',
+      apiSecret: 'apiSecret',
+      toolsMessageVersion: 1,
+      toolsMessage: 'flutterToolsMessage',
+      branch: 'ey-test-branch',
+      flutterVersion: 'Flutter 3.6.0-7.0.pre.47',
+      dartVersion: 'Dart 2.19.0',
+      fs: fs,
+    );
+  });
+
+  test('Initializer properly sets up on first run', () {
+    // The 3 files that should have been generated
+    final File clientIdFile =
+        home.childDirectory('.dart-tool').childFile('CLIENT_ID');
+    final File sessionFile =
+        home.childDirectory('.dart-tool').childFile('session.json');
+    final File configFile = home
+        .childDirectory('.dart-tool')
+        .childFile('dart-flutter-telemetry.config');
+
+    expect(clientIdFile.existsSync(), true,
+        reason: 'The CLIENT_ID file was not found');
+    expect(sessionFile.existsSync(), true,
+        reason: 'The session.json file was not found');
+    expect(configFile.existsSync(), true,
+        reason: 'The dart-flutter-telemetry.config was not found');
+    expect(dartToolDirectory.listSync().length, equals(3),
+        reason: 'There should only be 3 files in the .dart-tool directory');
+    expect(analytics.shouldShowMessage, true,
+        reason: 'For the first run, analytics should default to being enabled');
+  });
+}

--- a/test/dash_analytics_test.dart
+++ b/test/dash_analytics_test.dart
@@ -3,12 +3,24 @@ import 'package:file/memory.dart';
 import 'package:test/test.dart';
 
 import 'package:dash_analytics/dash_analytics.dart';
+import 'package:dash_analytics/src/config_handler.dart';
 
 void main() {
   late FileSystem fs;
   late Directory home;
   late Directory dartToolDirectory;
   late Analytics analytics;
+  late ConfigHandler configHandler;
+
+  const String initialToolName = 'initialTool';
+  const String secondTool = 'newTool';
+  const String measurementId = 'measurementId';
+  const String apiSecret = 'apiSecret';
+  const int toolsMessageVersion = 1;
+  const String toolsMessage = 'toolsMessage';
+  const String branch = 'branch';
+  const String flutterVersion = 'flutterVersion';
+  const String dartVersion = 'dartVersion';
 
   setUp(() {
     // Setup the filesystem with the home directory
@@ -17,15 +29,15 @@ void main() {
     dartToolDirectory = home.childDirectory('.dart-tool');
 
     analytics = Analytics.test(
-      tool: 'tool',
+      tool: initialToolName,
       homeDirectory: home,
-      measurementId: 'measurementId',
-      apiSecret: 'apiSecret',
-      toolsMessageVersion: 1,
-      toolsMessage: 'flutterToolsMessage',
-      branch: 'ey-test-branch',
-      flutterVersion: 'Flutter 3.6.0-7.0.pre.47',
-      dartVersion: 'Dart 2.19.0',
+      measurementId: measurementId,
+      apiSecret: apiSecret,
+      toolsMessageVersion: toolsMessageVersion,
+      toolsMessage: toolsMessage,
+      branch: branch,
+      flutterVersion: flutterVersion,
+      dartVersion: dartVersion,
       fs: fs,
     );
   });
@@ -50,5 +62,33 @@ void main() {
         reason: 'There should only be 3 files in the .dart-tool directory');
     expect(analytics.shouldShowMessage, true,
         reason: 'For the first run, analytics should default to being enabled');
+  });
+
+  test('New tool is successfully added to config file', () {
+    // Create a new instance of the analytics class with the new tool
+    final Analytics secondAnalytics = Analytics.test(
+      tool: secondTool,
+      homeDirectory: home,
+      measurementId: 'measurementId',
+      apiSecret: 'apiSecret',
+      toolsMessageVersion: 1,
+      toolsMessage: 'flutterToolsMessage',
+      branch: 'ey-test-branch',
+      flutterVersion: 'Flutter 3.6.0-7.0.pre.47',
+      dartVersion: 'Dart 2.19.0',
+      fs: fs,
+    );
+
+    // Access the config handler specifically to check adding a tool was
+    // was successful, this class will not be available for importing however
+    configHandler = ConfigHandler(fs: fs, homeDirectory: home);
+
+    expect(configHandler.parsedTools.length, equals(2),
+        reason: 'There should be only 2 tools that have '
+            'been parsed into the config file');
+    expect(configHandler.parsedTools.containsKey(initialToolName), true,
+        reason: 'The first tool: $initialToolName should be in the map');
+    expect(configHandler.parsedTools.containsKey(secondTool), true,
+        reason: 'The second tool: $secondAnalytics should be in the map');
   });
 }

--- a/test/dash_analytics_test.dart
+++ b/test/dash_analytics_test.dart
@@ -1,4 +1,5 @@
-import 'package:dash_analytics/dash_analytics.dart';
 import 'package:test/test.dart';
+
+import 'package:dash_analytics/dash_analytics.dart';
 
 void main() {}


### PR DESCRIPTION
Intended to be part of https://github.com/eliasyishak/dash_analytics/issues/5

A new method has been added to the `ConfigHandler` class that will allow for new tools being used by the user to get added to the configuration file. To handle this, the tool will take the `tool` string and check if it exists in the output from the `parseConfig()` method. If it doesn't exist, it will edit the file and enter a new entry for that tool at the bottom of the configuration file with version number = 1 and today's date.

The value will be defaulted to 1, future functionality will be added to increment the tool version if the version passed in is not actually 1.