### PR TITLE
Log handler functionality to persist and query local data

### DIFF
--- a/example/dash_analytics_example.dart
+++ b/example/dash_analytics_example.dart
@@ -12,7 +12,7 @@ final String apiSecret = '4yT8__oER3Cd84dtx6r-_A';
 // Globally instantiate the analytics class at the entry
 // point of the tool
 final Analytics analytics = Analytics(
-  tool: tool,
+  tool: DashTools.flutterTools,
   measurementId: measurementId,
   apiSecret: apiSecret,
   branch: 'ey-test-branch',
@@ -25,16 +25,10 @@ void main() {
   print('###### START ###### $start');
 
   print(analytics.telemetryEnabled);
-  DateTime begin;
-  // TODO: remove this code after PR is completed
-  for (int i = 0; i < 500; i++) {
-    begin = DateTime.now();
-    analytics.sendEvent(
-      eventName: DashEvents.hotReloadTime,
-      eventData: <String, int>{'time_ns': i},
-    );
-    print('${DateTime.now().difference(begin).inMicroseconds}');
-  }
+  analytics.sendEvent(
+    eventName: DashEvents.hotReloadTime,
+    eventData: <String, int>{'time_ns': 345},
+  );
   analytics.close();
 
   DateTime end = DateTime.now();

--- a/example/dash_analytics_example.dart
+++ b/example/dash_analytics_example.dart
@@ -4,8 +4,6 @@
 
 import 'package:dash_analytics/dash_analytics.dart';
 
-final String tool = 'flutter-tools';
-
 final String measurementId = 'G-N1NXG28J5B';
 final String apiSecret = '4yT8__oER3Cd84dtx6r-_A';
 

--- a/example/dash_analytics_example.dart
+++ b/example/dash_analytics_example.dart
@@ -24,7 +24,7 @@ void main() {
 
   print(analytics.telemetryEnabled);
   analytics.sendEvent(
-    eventName: DashEvents.hotReloadTime,
+    eventName: DashEvent.hotReloadTime,
     eventData: <String, int>{'time_ns': 345},
   );
   analytics.close();

--- a/example/dash_analytics_example.dart
+++ b/example/dash_analytics_example.dart
@@ -20,15 +20,21 @@ final Analytics analytics = Analytics(
   dartVersion: 'Dart 2.19.0',
 );
 
-void main() {
+Future<void> main() async {
   DateTime start = DateTime.now();
   print('###### START ###### $start');
 
   print(analytics.telemetryEnabled);
-  analytics.sendEvent(
-    eventName: DashEvents.hotReloadTime,
-    eventData: <String, int>{'time_ns': 345},
-  );
+  DateTime begin;
+  // TODO: remove this code after PR is completed
+  for (int i = 0; i < 500; i++) {
+    begin = DateTime.now();
+    await analytics.sendEvent(
+      eventName: DashEvents.hotReloadTime,
+      eventData: <String, int>{'time_ns': i},
+    );
+    print('${DateTime.now().difference(begin).inMicroseconds}');
+  }
   analytics.close();
 
   DateTime end = DateTime.now();

--- a/example/dash_analytics_example.dart
+++ b/example/dash_analytics_example.dart
@@ -20,7 +20,7 @@ final Analytics analytics = Analytics(
   dartVersion: 'Dart 2.19.0',
 );
 
-Future<void> main() async {
+void main() {
   DateTime start = DateTime.now();
   print('###### START ###### $start');
 
@@ -29,7 +29,7 @@ Future<void> main() async {
   // TODO: remove this code after PR is completed
   for (int i = 0; i < 500; i++) {
     begin = DateTime.now();
-    await analytics.sendEvent(
+    analytics.sendEvent(
       eventName: DashEvents.hotReloadTime,
       eventData: <String, int>{'time_ns': i},
     );

--- a/example/dash_analytics_example.dart
+++ b/example/dash_analytics_example.dart
@@ -12,7 +12,7 @@ final String apiSecret = '4yT8__oER3Cd84dtx6r-_A';
 // Globally instantiate the analytics class at the entry
 // point of the tool
 final Analytics analytics = Analytics(
-  tool: DashTools.flutterTools,
+  tool: DashTool.flutterTools,
   measurementId: measurementId,
   apiSecret: apiSecret,
   branch: 'ey-test-branch',

--- a/lib/dash_analytics.dart
+++ b/lib/dash_analytics.dart
@@ -4,3 +4,4 @@
 
 export 'src/analytics.dart' show Analytics;
 export 'src/enums.dart';
+export 'src/log_handler.dart' show LogFileStats;

--- a/lib/dash_analytics.dart
+++ b/lib/dash_analytics.dart
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 export 'src/analytics.dart' show Analytics;
-export 'src/enums.dart' show DashEvents, DashTools, LogFileQuery;
+export 'src/enums.dart';

--- a/lib/dash_analytics.dart
+++ b/lib/dash_analytics.dart
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 export 'src/analytics.dart' show Analytics;
-export 'src/enums.dart' show DashEvents, LogFileQuery;
+export 'src/enums.dart' show DashEvents, DashTools, LogFileQuery;

--- a/lib/dash_analytics.dart
+++ b/lib/dash_analytics.dart
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 export 'src/analytics.dart' show Analytics;
-export 'src/enums.dart';
+export 'src/enums.dart' show DashEvents, LogFileQuery;

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -24,7 +24,7 @@ abstract class Analytics {
   /// The default factory constructor that will return an implementation
   /// of the [Analytics] abstract class using the [LocalFileSystem]
   factory Analytics({
-    required DashTools tool,
+    required DashTool tool,
     required String measurementId,
     required String apiSecret,
     required String branch,

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -120,7 +120,9 @@ abstract class Analytics {
   void close();
 
   /// Query the persisted event data stored on the user's machine
-  LogFileStats logFileStats();
+  ///
+  /// Returns null if there are no persisted logs
+  LogFileStats? logFileStats();
 
   /// API to send events to Google Analytics to track usage
   Future<Response>? sendEvent({
@@ -236,7 +238,7 @@ class AnalyticsImpl implements Analytics {
   void close() => _gaClient.close();
 
   @override
-  LogFileStats logFileStats() => _logHandler.logFileStats();
+  LogFileStats? logFileStats() => _logHandler.logFileStats();
 
   @override
   Future<Response>? sendEvent({

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -255,7 +255,8 @@ class AnalyticsImpl implements Analytics {
   }
 
   @override
-  Future<void> setTelemetry(bool reportingBool) => _configHandler.setTelemetry(reportingBool);
+  Future<void> setTelemetry(bool reportingBool) =>
+      _configHandler.setTelemetry(reportingBool);
 }
 
 /// This class extends [AnalyticsImpl] and subs out any methods that

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -120,7 +120,7 @@ abstract class Analytics {
   void close();
 
   /// Query the persisted event data stored on the user's machine
-  Map<String, dynamic> query(LogFileQuery q);
+  LogFileStats logFileStats();
 
   /// API to send events to Google Analytics to track usage
   Future<Response>? sendEvent({
@@ -236,7 +236,7 @@ class AnalyticsImpl implements Analytics {
   void close() => _gaClient.close();
 
   @override
-  Map<String, dynamic> query(LogFileQuery q) => _logHandler.query(q);
+  LogFileStats logFileStats() => _logHandler.logFileStats();
 
   @override
   Future<Response>? sendEvent({
@@ -256,8 +256,7 @@ class AnalyticsImpl implements Analytics {
     _logHandler.save(data: body);
 
     // Pass to the google analytics client to send
-    // return _gaClient.sendData(body); TODO: uncomment once log handler is complete
-    return null;
+    return _gaClient.sendData(body);
   }
 
   @override

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -24,7 +24,7 @@ abstract class Analytics {
   /// The default factory constructor that will return an implementation
   /// of the [Analytics] abstract class using the [LocalFileSystem]
   factory Analytics({
-    required String tool,
+    required DashTools tool,
     required String measurementId,
     required String apiSecret,
     required String branch,
@@ -46,7 +46,7 @@ abstract class Analytics {
     }
 
     return AnalyticsImpl(
-      tool: tool,
+      tool: tool.label,
       homeDirectory: getHomeDirectory(fs),
       measurementId: measurementId,
       apiSecret: apiSecret,

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -296,12 +296,14 @@ class TestAnalytics extends AnalyticsImpl {
     // Calling the [generateRequestBody] method will ensure that the
     // session file is getting updated without actually making any
     // POST requests to Google Analytics
-    generateRequestBody(
+    final Map<String, dynamic> body = generateRequestBody(
       clientId: _clientId,
       eventName: eventName,
       eventData: eventData,
       userProperty: userProperty,
     );
+
+    _logHandler.save(data: body);
 
     return null;
   }

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -111,7 +111,7 @@ abstract class Analytics {
   /// Returns a map representation of the [UserProperty] for the [Analytics] instance
   ///
   /// This is what will get sent to Google Analytics with every request
-  Map<String, Map<String, dynamic>> get userPropertyMap;
+  Map<String, Map<String, Object?>> get userPropertyMap;
 
   /// Call this method when the tool using this package is closed
   ///
@@ -127,7 +127,7 @@ abstract class Analytics {
   /// API to send events to Google Analytics to track usage
   Future<Response>? sendEvent({
     required DashEvents eventName,
-    required Map<String, dynamic> eventData,
+    required Map<String, Object?> eventData,
   });
 
   /// Pass a boolean to either enable or disable telemetry and make
@@ -231,7 +231,7 @@ class AnalyticsImpl implements Analytics {
   bool get telemetryEnabled => _configHandler.telemetryEnabled;
 
   @override
-  Map<String, Map<String, dynamic>> get userPropertyMap =>
+  Map<String, Map<String, Object?>> get userPropertyMap =>
       userProperty.preparePayload();
 
   @override
@@ -243,12 +243,12 @@ class AnalyticsImpl implements Analytics {
   @override
   Future<Response>? sendEvent({
     required DashEvents eventName,
-    required Map<String, dynamic> eventData,
+    required Map<String, Object?> eventData,
   }) {
     if (!telemetryEnabled) return null;
 
     // Construct the body of the request
-    final Map<String, dynamic> body = generateRequestBody(
+    final Map<String, Object?> body = generateRequestBody(
       clientId: _clientId,
       eventName: eventName,
       eventData: eventData,
@@ -290,14 +290,14 @@ class TestAnalytics extends AnalyticsImpl {
   @override
   Future<Response>? sendEvent({
     required DashEvents eventName,
-    required Map<String, dynamic> eventData,
+    required Map<String, Object?> eventData,
   }) {
     if (!telemetryEnabled) return null;
 
     // Calling the [generateRequestBody] method will ensure that the
     // session file is getting updated without actually making any
     // POST requests to Google Analytics
-    final Map<String, dynamic> body = generateRequestBody(
+    final Map<String, Object?> body = generateRequestBody(
       clientId: _clientId,
       eventName: eventName,
       eventData: eventData,

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -119,6 +119,9 @@ abstract class Analytics {
   /// that need to be sent off
   void close();
 
+  /// Query the persisted event data stored on the user's machine
+  Map<String, dynamic> query(LogFileQuery q);
+
   /// API to send events to Google Analytics to track usage
   Future<Response>? sendEvent({
     required DashEvents eventName,
@@ -231,6 +234,9 @@ class AnalyticsImpl implements Analytics {
 
   @override
   void close() => _gaClient.close();
+
+  @override
+  Map<String, dynamic> query(LogFileQuery q) => _logHandler.query(q);
 
   @override
   Future<Response>? sendEvent({

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -126,7 +126,7 @@ abstract class Analytics {
 
   /// API to send events to Google Analytics to track usage
   Future<Response>? sendEvent({
-    required DashEvents eventName,
+    required DashEvent eventName,
     required Map<String, Object?> eventData,
   });
 
@@ -242,7 +242,7 @@ class AnalyticsImpl implements Analytics {
 
   @override
   Future<Response>? sendEvent({
-    required DashEvents eventName,
+    required DashEvent eventName,
     required Map<String, Object?> eventData,
   }) {
     if (!telemetryEnabled) return null;
@@ -289,7 +289,7 @@ class TestAnalytics extends AnalyticsImpl {
 
   @override
   Future<Response>? sendEvent({
-    required DashEvents eventName,
+    required DashEvent eventName,
     required Map<String, Object?> eventData,
   }) {
     if (!telemetryEnabled) return null;

--- a/lib/src/analytics.dart
+++ b/lib/src/analytics.dart
@@ -15,6 +15,7 @@ import 'constants.dart';
 import 'enums.dart';
 import 'ga_client.dart';
 import 'initializer.dart';
+import 'log_handler.dart';
 import 'session.dart';
 import 'user_property.dart';
 import 'utils.dart';
@@ -136,6 +137,7 @@ class AnalyticsImpl implements Analytics {
   late final GAClient _gaClient;
   late final String _clientId;
   late final UserProperty userProperty;
+  late final LogHandler _logHandler;
 
   @override
   final String toolsMessage;
@@ -209,6 +211,9 @@ class AnalyticsImpl implements Analytics {
       dartVersion: dartVersion,
       tool: tool,
     );
+
+    // Initialize the log handler to persist events that are being sent
+    _logHandler = LogHandler(fs: fs, homeDirectory: homeDirectory);
   }
 
   @override
@@ -242,8 +247,11 @@ class AnalyticsImpl implements Analytics {
       userProperty: userProperty,
     );
 
+    _logHandler.save(data: body);
+
     // Pass to the google analytics client to send
-    return _gaClient.sendData(body);
+    // return _gaClient.sendData(body); TODO: uncomment once log handler is complete
+    return null;
   }
 
   @override

--- a/lib/src/config_handler.dart
+++ b/lib/src/config_handler.dart
@@ -21,7 +21,7 @@ const String telemetryFlagPattern = r'^reporting=([0|1]) *$';
 /// Example:
 /// flutter-tools=2022-10-26,1
 const String toolPattern =
-    r'^([A-Za-z0-9]+-*[A-Za-z0-9]*)=([0-9]{4}-[0-9]{2}-[0-9]{2}),([0-9]+)$';
+    r'^([A-Za-z0-9]+_*[A-Za-z0-9]*)=([0-9]{4}-[0-9]{2}-[0-9]{2}),([0-9]+)$';
 
 class ConfigHandler {
   /// Regex pattern implementation for matching a line in the config file

--- a/lib/src/config_handler.dart
+++ b/lib/src/config_handler.dart
@@ -229,7 +229,7 @@ class ToolInfo {
 
   @override
   String toString() {
-    return json.encode(<String, dynamic>{
+    return json.encode(<String, Object?>{
       'lastRun': DateFormat('yyyy-MM-dd').format(lastRun),
       'versionNumber': versionNumber,
     });

--- a/lib/src/config_handler.dart
+++ b/lib/src/config_handler.dart
@@ -21,7 +21,7 @@ const String telemetryFlagPattern = r'^reporting=([0|1]) *$';
 /// Example:
 /// flutter-tools=2022-10-26,1
 const String toolPattern =
-    r'^([A-Za-z0-9]+_*[A-Za-z0-9]*)=([0-9]{4}-[0-9]{2}-[0-9]{2}),([0-9]+)$';
+    r'^([A-Za-z0-9]+-*[A-Za-z0-9]*)=([0-9]{4}-[0-9]{2}-[0-9]{2}),([0-9]+)$';
 
 class ConfigHandler {
   /// Regex pattern implementation for matching a line in the config file

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -56,7 +56,7 @@ reporting=1
 const String kDartToolDirectoryName = '.dart';
 
 /// How many data records to store in the log file
-const int kLogFileLength = 100;
+const int kLogFileLength = 2500;
 
 /// Filename for the log file to persist sent events on user's machine
 const String kLogFileName = 'dash-analytics.log';

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -55,6 +55,12 @@ reporting=1
 /// for this package will be located
 const String kDartToolDirectoryName = '.dart';
 
+/// How many data records to store in the log file
+const int kLogFileLength = 100;
+
+/// Filename for the log file to persist sent events on user's machine
+const String kLogFileName = 'dash-analytics.log';
+
 /// The minimum length for a session
 const int kSessionDurationMinutes = 30;
 

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -58,7 +58,7 @@ enum DevicePlatform {
 
 // Supported queries on the persisted log file
 enum LogFileQuery {
-  /// Returns the unique number of sessions along with how the start
+  /// Returns the unique number of sessions along with the start
   /// and end dates for the entire log file
   sessionCount,
   ;

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -24,9 +24,9 @@ enum DashEvents {
   });
 }
 
-/// The tools that have been onboarded
+/// Officially-supported clients of this package.
 ///
-/// All tools should use a hyphen as a delimiter
+/// All [label] values should use a hyphen as a delimiter
 enum DashTool {
   flutterTools(
     label: 'flutter-tools',

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -24,12 +24,37 @@ enum DashEvents {
   });
 }
 
+/// The tools that have been onboarded
+enum DashTools {
+  flutterTools(
+    label: 'flutter_tools',
+    description: 'Runs flutter applications',
+  ),
+  ;
+
+  final String label;
+  final String description;
+  const DashTools({
+    required this.label,
+    required this.description,
+  });
+}
+
 /// Enumerate options for platform
 enum DevicePlatform {
   windows('Windows'),
   macos('macOS'),
-  linux('Linux');
+  linux('Linux'),
+  ;
 
   final String label;
   const DevicePlatform(this.label);
+}
+
+// Supported queries on the persisted log file
+enum LogFileQuery {
+  /// Returns the unique number of sessions along with how the start
+  /// and end dates for the entire log file
+  sessionCount,
+  ;
 }

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -32,7 +32,10 @@ enum DashTools {
     label: 'flutter-tools',
     description: 'Runs flutter applications from CLI',
   ),
-  ;
+  dartAnalyzer(
+    label: 'dart-analyzer',
+    description: 'Analyzes dart code in workspace',
+  );
 
   final String label;
   final String description;

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -10,13 +10,13 @@ enum DashEvents {
   hotReloadTime(
     label: 'hot_reload_time',
     description: 'Hot reload duration',
-    toolOwner: 'flutter_tools',
+    toolOwner: DashTools.flutterTools,
   ),
   ;
 
   final String label;
   final String description;
-  final String toolOwner;
+  final DashTools toolOwner;
   const DashEvents({
     required this.label,
     required this.description,
@@ -26,12 +26,11 @@ enum DashEvents {
 
 /// The tools that have been onboarded
 ///
-/// All tools should use an underscore instead of
-/// a hyphen to split text
+/// All tools should use a hyphen as a delimiter
 enum DashTools {
   flutterTools(
-    label: 'flutter_tools',
-    description: 'Runs flutter applications',
+    label: 'flutter-tools',
+    description: 'Runs flutter applications from CLI',
   ),
   ;
 

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -6,7 +6,7 @@
 ///
 /// The [label] for each enum value is what will be logged, the [description]
 /// is here for documentation purposes
-enum DashEvents {
+enum DashEvent {
   hotReloadTime(
     label: 'hot_reload_time',
     description: 'Hot reload duration',
@@ -17,7 +17,7 @@ enum DashEvents {
   final String label;
   final String description;
   final DashTool toolOwner;
-  const DashEvents({
+  const DashEvent({
     required this.label,
     required this.description,
     required this.toolOwner,

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -55,11 +55,3 @@ enum DevicePlatform {
   final String label;
   const DevicePlatform(this.label);
 }
-
-// Supported queries on the persisted log file
-enum LogFileQuery {
-  /// Returns the unique number of sessions along with the start
-  /// and end dates for the entire log file
-  sessionCount,
-  ;
-}

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -4,7 +4,7 @@
 
 /// Values for the event name to be sent to Google Analytics
 ///
-/// The [label] for each enum value is what will be logged, the [desc]
+/// The [label] for each enum value is what will be logged, the [description]
 /// is here for documentation purposes
 enum DashEvents {
   hotReloadTime(

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -25,6 +25,9 @@ enum DashEvents {
 }
 
 /// The tools that have been onboarded
+///
+/// All tools should use an underscore instead of
+/// a hyphen to split text
 enum DashTools {
   flutterTools(
     label: 'flutter_tools',

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -10,13 +10,13 @@ enum DashEvents {
   hotReloadTime(
     label: 'hot_reload_time',
     description: 'Hot reload duration',
-    toolOwner: DashTools.flutterTools,
+    toolOwner: DashTool.flutterTools,
   ),
   ;
 
   final String label;
   final String description;
-  final DashTools toolOwner;
+  final DashTool toolOwner;
   const DashEvents({
     required this.label,
     required this.description,
@@ -27,7 +27,7 @@ enum DashEvents {
 /// The tools that have been onboarded
 ///
 /// All tools should use a hyphen as a delimiter
-enum DashTools {
+enum DashTool {
   flutterTools(
     label: 'flutter-tools',
     description: 'Runs flutter applications from CLI',
@@ -39,7 +39,7 @@ enum DashTools {
 
   final String label;
   final String description;
-  const DashTools({
+  const DashTool({
     required this.label,
     required this.description,
   });

--- a/lib/src/ga_client.dart
+++ b/lib/src/ga_client.dart
@@ -26,7 +26,7 @@ class GAClient {
 
   /// Receive the payload in Map form and parse
   /// into JSON to send to GA
-  Future<http.Response> sendData(Map<String, dynamic> body) {
+  Future<http.Response> sendData(Map<String, Object?> body) {
     return _client.post(
       Uri.parse(postUrl),
       headers: <String, String>{

--- a/lib/src/initializer.dart
+++ b/lib/src/initializer.dart
@@ -67,6 +67,12 @@ $tool=$dateStamp,$toolsMessageVersion
 ''');
   }
 
+  /// Creates that log file that will store the record formatted
+  /// events locally on the user's machine
+  void createLogFile({required File logFile}) {
+    logFile.createSync(recursive: true);
+  }
+
   /// Creates the session json file which will contain
   /// the current session id along with the timestamp for
   /// the last ping which will be used to increment the session
@@ -116,6 +122,13 @@ $tool=$dateStamp,$toolsMessageVersion
         p.join(homeDirectory.path, kDartToolDirectoryName, kSessionFileName));
     if (!sessionFile.existsSync()) {
       createSessionFile(sessionFile: sessionFile);
+    }
+
+    // Begin initialization checks for the log file to persist events locally
+    final File logFile = fs
+        .file(p.join(homeDirectory.path, kDartToolDirectoryName, kLogFileName));
+    if (!logFile.existsSync()) {
+      createLogFile(logFile: logFile);
     }
   }
 }

--- a/lib/src/log_handler.dart
+++ b/lib/src/log_handler.dart
@@ -6,6 +6,24 @@ import 'package:path/path.dart' as p;
 import 'constants.dart';
 import 'initializer.dart';
 
+class LogFileStats {
+  /// The oldest timestamp in the log file
+  final DateTime startDateTime;
+
+  /// The latest timestamp in the log file
+  final DateTime endDateTime;
+
+  /// The number of unique session ids found in the log file
+  final int sessionCount;
+
+  /// Contains the data from the [LogHandler.logFileStats]
+  LogFileStats({
+    required this.startDateTime,
+    required this.endDateTime,
+    required this.sessionCount,
+  });
+}
+
 class LogHandler {
   final FileSystem fs;
   final Directory homeDirectory;
@@ -24,26 +42,6 @@ class LogHandler {
           kDartToolDirectoryName,
           kLogFileName,
         ));
-
-  /// Saves the data passed in as a single line in the log file
-  ///
-  /// This will keep the max number of records limited to equal to
-  /// or less than [kLogFileLength] records
-  void save({required Map<String, dynamic> data}) {
-    List<String> records = logFile.readAsLinesSync();
-    final String content = '${jsonEncode(data)}\n';
-
-    // When the record count is less than the max, add as normal;
-    // else drop the oldest records until equal to max
-    if (records.length < kLogFileLength) {
-      logFile.writeAsStringSync(content, mode: FileMode.writeOnlyAppend);
-    } else {
-      records.add(content);
-      records = records.skip(records.length - kLogFileLength).toList();
-
-      logFile.writeAsStringSync(records.join('\n'));
-    }
-  }
 
   /// Get stats from the persisted log file
   LogFileStats logFileStats() {
@@ -69,22 +67,24 @@ class LogHandler {
       sessionCount: sessionCount,
     );
   }
-}
 
-class LogFileStats {
-  /// The oldest timestamp in the log file
-  final DateTime startDateTime;
+  /// Saves the data passed in as a single line in the log file
+  ///
+  /// This will keep the max number of records limited to equal to
+  /// or less than [kLogFileLength] records
+  void save({required Map<String, dynamic> data}) {
+    List<String> records = logFile.readAsLinesSync();
+    final String content = '${jsonEncode(data)}\n';
 
-  /// The latest timestamp in the log file
-  final DateTime endDateTime;
+    // When the record count is less than the max, add as normal;
+    // else drop the oldest records until equal to max
+    if (records.length < kLogFileLength) {
+      logFile.writeAsStringSync(content, mode: FileMode.writeOnlyAppend);
+    } else {
+      records.add(content);
+      records = records.skip(records.length - kLogFileLength).toList();
 
-  /// The number of unique session ids found in the log file
-  final int sessionCount;
-
-  /// Contains the data from the [LogHandler.logFileStats]
-  LogFileStats({
-    required this.startDateTime,
-    required this.endDateTime,
-    required this.sessionCount,
-  });
+      logFile.writeAsStringSync(records.join('\n'));
+    }
+  }
 }

--- a/lib/src/log_handler.dart
+++ b/lib/src/log_handler.dart
@@ -1,0 +1,19 @@
+import 'package:file/file.dart';
+
+import 'constants.dart';
+import 'initializer.dart';
+
+class LogHandler {
+  final FileSystem fs;
+  final Directory homeDirectory;
+
+  /// This class is responsible for writing to a log
+  /// file that has been initialized by the [Initializer]
+  ///
+  /// It will be treated as an append only log and will be limited
+  /// to have has many data records as specified by [kLogFileLength]
+  LogHandler({
+    required this.fs,
+    required this.homeDirectory,
+  });
+}

--- a/lib/src/log_handler.dart
+++ b/lib/src/log_handler.dart
@@ -22,6 +22,13 @@ class LogFileStats {
     required this.endDateTime,
     required this.sessionCount,
   });
+
+  @override
+  String toString() => jsonEncode({
+        'startDateTime': startDateTime.toString(),
+        'endDateTime': endDateTime.toString(),
+        'sessionCount': sessionCount,
+      });
 }
 
 class LogHandler {

--- a/lib/src/log_handler.dart
+++ b/lib/src/log_handler.dart
@@ -243,7 +243,9 @@ class LogItem {
         tool: tool!,
         localTime: localTime,
       );
-    } on Exception {
+    } on TypeError {
+      return null;
+    } on FormatException {
       return null;
     }
   }

--- a/lib/src/log_handler.dart
+++ b/lib/src/log_handler.dart
@@ -31,16 +31,18 @@ class LogFileStats {
       });
 }
 
+/// This class is responsible for writing to a log
+/// file that has been initialized by the [Initializer]
+///
+/// It will be treated as an append only log and will be limited
+/// to have has many data records as specified by [kLogFileLength]
 class LogHandler {
   final FileSystem fs;
   final Directory homeDirectory;
   final File logFile;
 
-  /// This class is responsible for writing to a log
-  /// file that has been initialized by the [Initializer]
-  ///
-  /// It will be treated as an append only log and will be limited
-  /// to have has many data records as specified by [kLogFileLength]
+  /// A log handler constructor that will delegate saving
+  /// logs and retrieving stats from the persisted log
   LogHandler({
     required this.fs,
     required this.homeDirectory,

--- a/lib/src/log_handler.dart
+++ b/lib/src/log_handler.dart
@@ -30,7 +30,7 @@ class LogHandler {
   /// This will keep the max number of records limited to equal to
   /// or less than [kLogFileLength] records
   void save({required Map<String, dynamic> data}) {
-    final List<String> records = logFile.readAsLinesSync();
+    List<String> records = logFile.readAsLinesSync();
     final String content = '${jsonEncode(data)}\n';
 
     // When the record count is less than the max, add as normal;
@@ -38,8 +38,8 @@ class LogHandler {
     if (records.length < kLogFileLength) {
       logFile.writeAsStringSync(content, mode: FileMode.writeOnlyAppend);
     } else {
-      records.removeAt(0);
       records.add(content);
+      records = records.skip(records.length - kLogFileLength).toList();
 
       logFile.writeAsStringSync(records.join('\n'));
     }

--- a/lib/src/log_handler.dart
+++ b/lib/src/log_handler.dart
@@ -16,8 +16,8 @@ class LogFileStats {
   /// The number of unique session ids found in the log file
   final int sessionCount;
 
-  /// Contains the data from the [LogHandler.logFileStats]
-  LogFileStats({
+  /// Contains the data from the [LogHandler.logFileStats] method
+  const LogFileStats({
     required this.startDateTime,
     required this.endDateTime,
     required this.sessionCount,

--- a/lib/src/log_handler.dart
+++ b/lib/src/log_handler.dart
@@ -47,6 +47,9 @@ class LogHandler {
   }
 
   /// Query the persisted log file using the persisted log file
+  ///
+  /// [q] is the type of query to make, the list of queries is enumerated
+  /// in [LogFileQuery]
   Map<String, dynamic> query(LogFileQuery q) {
     Iterable<Map<String, dynamic>> records =
         logFile.readAsLinesSync().map((String e) => jsonDecode(e));

--- a/lib/src/log_handler.dart
+++ b/lib/src/log_handler.dart
@@ -24,7 +24,7 @@ class LogFileStats {
   });
 
   @override
-  String toString() => jsonEncode({
+  String toString() => jsonEncode(<String, dynamic>{
         'startDateTime': startDateTime.toString(),
         'endDateTime': endDateTime.toString(),
         'sessionCount': sessionCount,
@@ -51,9 +51,11 @@ class LogHandler {
         ));
 
   /// Get stats from the persisted log file
-  LogFileStats logFileStats() {
+  LogFileStats? logFileStats() {
     Iterable<Map<String, dynamic>> records =
         logFile.readAsLinesSync().map((String e) => jsonDecode(e));
+
+    if (records.isEmpty) return null;
 
     // Get the start and end dates for the log file
     final DateTime startDateTime =

--- a/lib/src/log_handler.dart
+++ b/lib/src/log_handler.dart
@@ -1,4 +1,7 @@
+import 'dart:convert';
+
 import 'package:file/file.dart';
+import 'package:path/path.dart' as p;
 
 import 'constants.dart';
 import 'initializer.dart';
@@ -6,6 +9,7 @@ import 'initializer.dart';
 class LogHandler {
   final FileSystem fs;
   final Directory homeDirectory;
+  final File logFile;
 
   /// This class is responsible for writing to a log
   /// file that has been initialized by the [Initializer]
@@ -15,5 +19,29 @@ class LogHandler {
   LogHandler({
     required this.fs,
     required this.homeDirectory,
-  });
+  }) : logFile = fs.file(p.join(
+          homeDirectory.path,
+          kDartToolDirectoryName,
+          kLogFileName,
+        ));
+
+  /// Saves the data passed in as a single line in the log file
+  ///
+  /// This will keep the max number of records limited to equal to
+  /// or less than [kLogFileLength] records
+  void save({required Map<String, dynamic> data}) {
+    final List<String> records = logFile.readAsLinesSync();
+    final String content = '${jsonEncode(data)}\n';
+
+    // When the record count is less than the max, add as normal;
+    // else drop the oldest records until equal to max
+    if (records.length < kLogFileLength) {
+      logFile.writeAsStringSync(content, mode: FileMode.writeOnlyAppend);
+    } else {
+      records.removeAt(0);
+      records.add(content);
+
+      logFile.writeAsStringSync(records.join('\n'));
+    }
+  }
 }

--- a/lib/src/log_handler.dart
+++ b/lib/src/log_handler.dart
@@ -4,6 +4,7 @@ import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 
 import 'constants.dart';
+import 'enums.dart';
 import 'initializer.dart';
 
 class LogHandler {
@@ -43,5 +44,30 @@ class LogHandler {
 
       logFile.writeAsStringSync(records.join('\n'));
     }
+  }
+
+  /// Query the persisted log file using the persisted log file
+  Map<String, dynamic> query(LogFileQuery q) {
+    Iterable<Map<String, dynamic>> records =
+        logFile.readAsLinesSync().map((String e) => jsonDecode(e));
+    Map<String, dynamic> results = <String, dynamic>{};
+
+    // Get the start and end dates for the log file
+    results['start_datetime'] =
+        DateTime.parse(records.first['user_properties']['local_time']['value']);
+    results['end_datetime'] =
+        DateTime.parse(records.last['user_properties']['local_time']['value']);
+
+    switch (q) {
+      case LogFileQuery.sessionCount:
+        final Set<int> sessions = <int>{};
+        for (Map<String, dynamic> element in records) {
+          sessions.add(element['user_properties']['session_id']['value']);
+        }
+        results['session_count'] = sessions.length;
+        break;
+    }
+
+    return results;
   }
 }

--- a/lib/src/session.dart
+++ b/lib/src/session.dart
@@ -28,7 +28,7 @@ class Session {
         p.join(homeDirectory.path, kDartToolDirectoryName, kSessionFileName));
 
     final String sessionFileContents = sessionFile.readAsStringSync();
-    final Map<String, dynamic> sessionObj = jsonDecode(sessionFileContents);
+    final Map<String, Object?> sessionObj = jsonDecode(sessionFileContents);
     final int sessionId = sessionObj['session_id'] as int;
     final int lastPing = sessionObj['last_ping'] as int;
 
@@ -101,7 +101,7 @@ class Session {
   /// making updates to the session file
   void _refreshSessionData() {
     final String sessionFileContents = _sessionFile.readAsStringSync();
-    final Map<String, dynamic> sessionObj = jsonDecode(sessionFileContents);
+    final Map<String, Object?> sessionObj = jsonDecode(sessionFileContents);
     _sessionId = sessionObj['session_id'] as int;
     _lastPing = sessionObj['last_ping'] as int;
   }

--- a/lib/src/user_property.dart
+++ b/lib/src/user_property.dart
@@ -35,10 +35,10 @@ class UserProperty {
   /// update the session file and get a new session id if necessary
   ///
   /// https://developers.google.com/analytics/devguides/collection/protocol/ga4/user-properties?client_type=gtag
-  Map<String, Map<String, dynamic>> preparePayload() {
-    return <String, Map<String, dynamic>>{
-      for (MapEntry<String, dynamic> entry in _toMap().entries)
-        entry.key: <String, dynamic>{'value': entry.value}
+  Map<String, Map<String, Object?>> preparePayload() {
+    return <String, Map<String, Object?>>{
+      for (MapEntry<String, Object?> entry in _toMap().entries)
+        entry.key: <String, Object?>{'value': entry.value}
     };
   }
 
@@ -49,7 +49,7 @@ class UserProperty {
 
   /// Convert the data stored in this class into a map while also
   /// getting the latest session id using the [Session] class
-  Map<String, dynamic> _toMap() => <String, dynamic>{
+  Map<String, Object?> _toMap() => <String, Object?>{
         'session_id': session.getSessionId(),
         'branch': branch,
         'host': host,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -31,16 +31,16 @@ import 'user_property.dart';
 /// }
 /// ```
 /// https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag
-Map<String, dynamic> generateRequestBody({
+Map<String, Object?> generateRequestBody({
   required String clientId,
   required DashEvent eventName,
-  required Map<String, dynamic> eventData,
+  required Map<String, Object?> eventData,
   required UserProperty userProperty,
 }) =>
-    <String, dynamic>{
+    <String, Object?>{
       'client_id': clientId,
-      'events': <Map<String, dynamic>>[
-        <String, dynamic>{
+      'events': <Map<String, Object?>>[
+        <String, Object?>{
           'name': eventName.label,
           'params': eventData,
         }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -33,7 +33,7 @@ import 'user_property.dart';
 /// https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag
 Map<String, dynamic> generateRequestBody({
   required String clientId,
-  required DashEvents eventName,
+  required DashEvent eventName,
   required Map<String, dynamic> eventData,
   required UserProperty userProperty,
 }) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dash_analytics
 description: A package for logging analytics for all dash related tooling to Google Analytics
-version: 1.0.0
+version: 0.0.1
 # repository: https://github.com/my_org/my_repo
 
 environment:

--- a/test/dash_analytics_test.dart
+++ b/test/dash_analytics_test.dart
@@ -745,4 +745,48 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
     expect(query!.toolCount, 2,
         reason: 'There should have been two tools in the persisted logs');
   });
+
+  test('Check that log data missing some keys results in null for stats', () {
+    // The following string represents a log item that is malformed (missing the `tool` key)
+    const String malformedLog =
+        '{"client_id":"d40133a0-7ea6-4347-b668-ffae94bb8774",'
+        '"events":[{"name":"hot_reload_time","params":{"time_ns":345}}],'
+        '"user_properties":{'
+        '"session_id":{"value":1675193534342},'
+        '"branch":{"value":"ey-test-branch"},'
+        '"host":{"value":"macOS"},'
+        '"flutter_version":{"value":"Flutter 3.6.0-7.0.pre.47"},'
+        '"dart_version":{"value":"Dart 2.19.0"},'
+        // '"tool":{"value":"flutter-tools"},'  NEEDS REMAIN REMOVED
+        '"local_time":{"value":"2023-01-31 14:32:14.592898"}}}';
+
+    logFile.writeAsStringSync(malformedLog);
+    final LogFileStats? query = analytics.logFileStats();
+
+    expect(query, isNull,
+        reason:
+            'The query should be null because `tool` is missing under `user_properties`');
+  });
+
+  test('Malformed local_time string should result in null for stats', () {
+    // The following string represents a log item that is malformed (missing the `tool` key)
+    const String malformedLog =
+        '{"client_id":"d40133a0-7ea6-4347-b668-ffae94bb8774",'
+        '"events":[{"name":"hot_reload_time","params":{"time_ns":345}}],'
+        '"user_properties":{'
+        '"session_id":{"value":1675193534342},'
+        '"branch":{"value":"ey-test-branch"},'
+        '"host":{"value":"macOS"},'
+        '"flutter_version":{"value":"Flutter 3.6.0-7.0.pre.47"},'
+        '"dart_version":{"value":"Dart 2.19.0"},'
+        '"tool":{"value":"flutter-tools"},'
+        '"local_time":{"value":"2023-xx-31 14:32:14.592898"}}}'; // PURPOSEFULLY MALFORMED
+
+    logFile.writeAsStringSync(malformedLog);
+    final LogFileStats? query = analytics.logFileStats();
+
+    expect(query, isNull,
+        reason:
+            'The query should be null because the `local_time` value is malformed');
+  });
 }

--- a/test/dash_analytics_test.dart
+++ b/test/dash_analytics_test.dart
@@ -645,4 +645,21 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
         (body['events'][0] as Map<String, dynamic>).containsKey('params'), true,
         reason: 'Each event in the events array needs a params key');
   });
+
+  test(
+      'All DashTools labels are made of characters that are letters or hyphens',
+      () {
+    // Regex pattern to match only letters or hyphens
+    final RegExp toolLabelPattern = RegExp(r'^[a-zA-Z\-]+$');
+    bool valid = true;
+    for (DashTools tool in DashTools.values) {
+      if (!toolLabelPattern.hasMatch(tool.label)) {
+        valid = false;
+      }
+    }
+
+    expect(valid, true,
+        reason: 'All tool labels should have letters and hyphens '
+            'as a delimiter if needed');
+  });
 }

--- a/test/dash_analytics_test.dart
+++ b/test/dash_analytics_test.dart
@@ -655,7 +655,7 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
     // Regex pattern to match only letters or hyphens
     final RegExp toolLabelPattern = RegExp(r'^[a-zA-Z\-]+$');
     bool valid = true;
-    for (DashTools tool in DashTools.values) {
+    for (DashTool tool in DashTool.values) {
       if (!toolLabelPattern.hasMatch(tool.label)) {
         valid = false;
       }

--- a/test/dash_analytics_test.dart
+++ b/test/dash_analytics_test.dart
@@ -14,7 +14,6 @@ import 'package:test/test.dart';
 import 'package:dash_analytics/dash_analytics.dart';
 import 'package:dash_analytics/src/config_handler.dart';
 import 'package:dash_analytics/src/constants.dart';
-import 'package:dash_analytics/src/log_handler.dart';
 import 'package:dash_analytics/src/session.dart';
 import 'package:dash_analytics/src/user_property.dart';
 import 'package:dash_analytics/src/utils.dart';
@@ -689,10 +688,13 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
   });
 
   test('Check the sessionCount query works as expected', () {
+    expect(analytics.logFileStats(), isNull,
+        reason: 'The result for the log file stats should be null when '
+            'there are no logs');
     analytics.sendEvent(
         eventName: DashEvents.hotReloadTime, eventData: <String, dynamic>{});
 
-    final LogFileStats firstQuery = analytics.logFileStats();
+    final LogFileStats firstQuery = analytics.logFileStats()!;
     expect(firstQuery.sessionCount, 1,
         reason:
             'There should only be one session after the initial send event');
@@ -707,7 +709,7 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
           eventName: DashEvents.hotReloadTime, eventData: <String, dynamic>{});
     });
 
-    final LogFileStats secondQuery = analytics.logFileStats();
+    final LogFileStats secondQuery = analytics.logFileStats()!;
     expect(secondQuery.sessionCount, 2,
         reason: 'There should be 2 sessions after the second event');
   });

--- a/test/dash_analytics_test.dart
+++ b/test/dash_analytics_test.dart
@@ -504,7 +504,7 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
       // getting updated but because we use the `Analytics.test()` constructor
       // no events will be sent
       thirdAnalytics.sendEvent(
-          eventName: DashEvents.hotReloadTime, eventData: <String, dynamic>{});
+          eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
 
       // Read the contents of the session file
       final String sessionFileContents = sessionFile.readAsStringSync();
@@ -556,7 +556,7 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
       expect(sessionObj['last_ping'], start.millisecondsSinceEpoch);
 
       secondAnalytics.sendEvent(
-          eventName: DashEvents.hotReloadTime, eventData: <String, dynamic>{});
+          eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
     });
 
     // Add time to the start time that is less than the duration
@@ -586,7 +586,7 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
       // getting updated but because we use the `Analytics.test()` constructor
       // no events will be sent
       thirdAnalytics.sendEvent(
-          eventName: DashEvents.hotReloadTime, eventData: <String, dynamic>{});
+          eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
 
       // Read the contents of the session file
       final String sessionFileContents = sessionFile.readAsStringSync();
@@ -618,7 +618,7 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
 
     final Map<String, dynamic> body = generateRequestBody(
       clientId: Uuid().generateV4(),
-      eventName: DashEvents.hotReloadTime,
+      eventName: DashEvent.hotReloadTime,
       eventData: eventData,
       userProperty: userProperty,
     );
@@ -671,7 +671,7 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
 
     for (int i = 0; i < numberOfEvents; i++) {
       analytics.sendEvent(
-          eventName: DashEvents.hotReloadTime, eventData: <String, dynamic>{});
+          eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
     }
 
     expect(logFile.readAsLinesSync().length, numberOfEvents,
@@ -680,7 +680,7 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
     // Add the max number of events to confirm it does not exceed the max
     for (int i = 0; i < kLogFileLength; i++) {
       analytics.sendEvent(
-          eventName: DashEvents.hotReloadTime, eventData: <String, dynamic>{});
+          eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
     }
 
     expect(logFile.readAsLinesSync().length, kLogFileLength,
@@ -692,7 +692,7 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
         reason: 'The result for the log file stats should be null when '
             'there are no logs');
     analytics.sendEvent(
-        eventName: DashEvents.hotReloadTime, eventData: <String, dynamic>{});
+        eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
 
     final LogFileStats firstQuery = analytics.logFileStats()!;
     expect(firstQuery.sessionCount, 1,
@@ -706,7 +706,7 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
     // Use the new clock to send an event that will change the session identifier
     withClock(Clock.fixed(firstClock), () {
       analytics.sendEvent(
-          eventName: DashEvents.hotReloadTime, eventData: <String, dynamic>{});
+          eventName: DashEvent.hotReloadTime, eventData: <String, dynamic>{});
     });
 
     final LogFileStats secondQuery = analytics.logFileStats()!;

--- a/test/dash_analytics_test.dart
+++ b/test/dash_analytics_test.dart
@@ -13,6 +13,7 @@ import 'package:test/test.dart';
 import 'package:dash_analytics/dash_analytics.dart';
 import 'package:dash_analytics/src/config_handler.dart';
 import 'package:dash_analytics/src/constants.dart';
+import 'package:dash_analytics/src/enums.dart';
 import 'package:dash_analytics/src/session.dart';
 import 'package:dash_analytics/src/user_property.dart';
 import 'package:dash_analytics/src/utils.dart';

--- a/test/dash_analytics_test.dart
+++ b/test/dash_analytics_test.dart
@@ -14,6 +14,7 @@ import 'package:test/test.dart';
 import 'package:dash_analytics/dash_analytics.dart';
 import 'package:dash_analytics/src/config_handler.dart';
 import 'package:dash_analytics/src/constants.dart';
+import 'package:dash_analytics/src/log_handler.dart';
 import 'package:dash_analytics/src/session.dart';
 import 'package:dash_analytics/src/user_property.dart';
 import 'package:dash_analytics/src/utils.dart';
@@ -691,11 +692,8 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
     analytics.sendEvent(
         eventName: DashEvents.hotReloadTime, eventData: <String, dynamic>{});
 
-    final Map<String, dynamic> firstQuery =
-        analytics.query(LogFileQuery.sessionCount);
-    expect(firstQuery.containsKey('session_count'), true,
-        reason: 'The session_count variable should have been returned');
-    expect(firstQuery['session_count'], 1,
+    final LogFileStats firstQuery = analytics.logFileStats();
+    expect(firstQuery.sessionCount, 1,
         reason:
             'There should only be one session after the initial send event');
 
@@ -709,11 +707,8 @@ $initialToolName=${ConfigHandler.dateStamp},$toolsMessageVersion
           eventName: DashEvents.hotReloadTime, eventData: <String, dynamic>{});
     });
 
-    final Map<String, dynamic> secondQuery =
-        analytics.query(LogFileQuery.sessionCount);
-    expect(secondQuery.containsKey('session_count'), true,
-        reason: 'The session_count variable should have been returned');
-    expect(secondQuery['session_count'], 2,
+    final LogFileStats secondQuery = analytics.logFileStats();
+    expect(secondQuery.sessionCount, 2,
         reason: 'There should be 2 sessions after the second event');
   });
 }

--- a/test/dash_analytics_test.dart
+++ b/test/dash_analytics_test.dart
@@ -25,6 +25,7 @@ void main() {
   late File clientIdFile;
   late File sessionFile;
   late File configFile;
+  late File logFile;
   late UserProperty userProperty;
 
   const String homeDirName = 'home';
@@ -71,6 +72,8 @@ void main() {
         home.childDirectory(kDartToolDirectoryName).childFile(kSessionFileName);
     configFile =
         home.childDirectory(kDartToolDirectoryName).childFile(kConfigFileName);
+    logFile =
+        home.childDirectory(kDartToolDirectoryName).childFile(kLogFileName);
 
     // Create the user property object that is also
     // created within analytics for testing
@@ -93,9 +96,11 @@ void main() {
         reason: 'The $kSessionFileName file was not found');
     expect(configFile.existsSync(), true,
         reason: 'The $kConfigFileName was not found');
-    expect(dartToolDirectory.listSync().length, equals(3),
+    expect(logFile.existsSync(), true,
+        reason: 'The $kLogFileName file was not found');
+    expect(dartToolDirectory.listSync().length, equals(4),
         reason:
-            'There should only be 3 files in the $kDartToolDirectoryName directory');
+            'There should only be 4 files in the $kDartToolDirectoryName directory');
     expect(analytics.shouldShowMessage, true,
         reason: 'For the first run, analytics should default to being enabled');
   });


### PR DESCRIPTION
Functionality has been added to persist the events that have been sent to GA locally on the user's machine while also implementing a max number of logs to persist as defined by `kLogFileLength` in `lib/src/constants.dart`. A log handler method has also been added to query the persisted data for stats around usage on the user's machine, such as unique count of sessions, etc.

https://github.com/eliasyishak/dash_analytics/issues/4 – issue for persisting the data
https://github.com/eliasyishak/dash_analytics/issues/11 – issue for querying the locally persisted data
